### PR TITLE
Launch improvements

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -46,7 +46,7 @@ do
   done
 
   echo "🛠  [HOST] Configuring runner on VM"
-  ssh -q $VM_USERNAME@$IP_ADDRESS "$VM_RUNNER_PATH/config.sh --url $RUNNER_URL --token $REGISTRATION_TOKEN --ephemeral --name $RUNNER_NAME --labels $RUNNER_LABELS --unattended --replace --disableupdate" > /dev/null
+  ssh -q $VM_USERNAME@$IP_ADDRESS "$VM_RUNNER_PATH/config.sh --url $RUNNER_URL --token $REGISTRATION_TOKEN --ephemeral --name $RUNNER_NAME --labels $RUNNER_LABELS --unattended --replace" > /dev/null
 
   echo "🏃 [HOST] Starting runner on VM"
   ssh -q $VM_USERNAME@$IP_ADDRESS "$VM_RUNNER_PATH/run.sh" 2>&1 | sed -nr 's/^(.+)$/📀 [GUEST] \1/p'


### PR DESCRIPTION
This PR make it so we don't need to set a host name in the VM in order to connect to it. Instead, it uses `arp` to resolve the IP address from the MAC address provided by `macosvm`.

I also explored the possibility of using a PTTY instead, but I didn't find a way to wait for a command's completion like we do with ssh.

This should allow us to run multiple VM on the same host.