### PR TITLE
Stop VM with tart instead of sending remote “sudo halt” command

### DIFF
--- a/host/launch.sh
+++ b/host/launch.sh
@@ -84,11 +84,8 @@ do
   log_output "[HOST] 🏃 Starting runner on VM"
   ssh -q $VM_USERNAME@$IP_ADDRESS "source ~/.zprofile && ./actions-runner/run.sh" 2>&1 | sed -nru 's/^(.+)$/[GUEST] 📀 \1/p' | stream_output
 
-  log_output "[HOST] 🪓 Sending kill command to VM"
-  ssh -q $VM_USERNAME@$IP_ADDRESS "sudo halt" > /dev/null 2>&1
-
-  log_output "[HOST] 🔌 Waiting for the VM to shut down"
-  wait $PID
+  log_output "[HOST] ✋ Stop the VM"
+  tart stop $INSTANCE_NAME
 
   log_output "[HOST] 🧹 Cleanup the VM"
   tart delete $INSTANCE_NAME


### PR DESCRIPTION
Suite à [ce problème](https://mirego.slack.com/archives/CM08DHL7N/p1672756786982849) où envoyer `sudo halt` via SSH à la VM nous demande le password du user `runner`, je me suis dit qu’on pourrait plutôt arrêter la VM via `tart stop`.

Oui, on contourne le vrai problème (ie. _password-less sudo_ qui fonctionne 25% du temps? 🤷) mais ça me semble plus propre, à la base 🙂 