### PR TITLE
Update GUI system preferences in host instructions

### DIFF
--- a/host/README.md
+++ b/host/README.md
@@ -14,12 +14,12 @@ Use `admin` as the username for the initial user
 - Displays → Advanced… → Energy → enable **Prevent automatic sleeping when display is off**
 
 <table>
-<tr>
-	<th>Sharing
-	<th>Displays
-<tr>
-	<td><img width="300" alt="Capture d’écran, le 2023-01-18 à 14 21 43" src="https://user-images.githubusercontent.com/11348/213275950-7e9976dc-f2b4-456f-a915-fcda26af6afc.png">
-	<td><img width="300" alt="Capture d’écran, le 2023-01-18 à 14 21 58" src="https://user-images.githubusercontent.com/11348/213275979-c53d5c69-2028-4277-aef3-3af502dcdba6.png">
+  <tr>
+    <th>Sharing
+    <th>Displays
+  <tr>
+    <td><img width="300" alt="Capture d’écran, le 2023-01-18 à 14 21 43" src="https://user-images.githubusercontent.com/11348/213275950-7e9976dc-f2b4-456f-a915-fcda26af6afc.png">
+    <td><img width="300" alt="Capture d’écran, le 2023-01-18 à 14 21 58" src="https://user-images.githubusercontent.com/11348/213275979-c53d5c69-2028-4277-aef3-3af502dcdba6.png">
 </table>
 
 ## CLI


### PR DESCRIPTION
On met à jour les instructions de configuration des préférences système du nouvel _host_ parce que leur emplacement a changé depuis macOS 13.