### PR TITLE
Add `launchctl` service and ditch Tmux

### DIFF
--- a/host/README.md
+++ b/host/README.md
@@ -40,6 +40,7 @@ Still from your local machine, copy a few files from this repository. The `domai
 ```
 $ scp domain.crt admin@<HOST_IP>
 $ scp launch.sh admin@<HOST_IP>:vm
+$ scp com.mirego.ekiden.plist admin@<HOST_IP>:vm
 $ scp .env admin@<HOST_IP>:vm
 $ scp id_rsa admin@<HOST_IP>:.ssh
 $ scp id_rsa.pub admin@<HOST_IP>:.ssh
@@ -47,11 +48,11 @@ $ scp id_rsa.pub admin@<HOST_IP>:.ssh
 
 ### Install Tools
 
-On the remote machine, install [Homebrew](https://brew.sh), `tmux`, `wget` and [tart](https://github.com/cirruslabs/tart/)
+On the remote machine, install [Homebrew](https://brew.sh), `wget` and [tart](https://github.com/cirruslabs/tart/)
 
 ```
 $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-$ brew install tmux wget cirruslabs/cli/tart
+$ brew install wget cirruslabs/cli/tart
 ```
 
 ### Install Certificate
@@ -67,12 +68,12 @@ $ security add-trusted-cert -d -k ~/Library/Keychains/login.keychain domain.crt
 
 ### Start the Runner
 
-Start tmux and launch a new runner!
+Install the service and launch it.
 
 ```
-$ tmux
-$ cd vm
-$ ./launch.sh
+$ sudo chown root:wheel launch.sh
+$ sudo cp com.mirego.ekiden /Library/LaunchDaemons
+$ sudo launchctl load -w /Library/LaunchDaemons/com.mirego.ekiden.plist
 ```
 
-You can now detach from tmux with (press `^B`, release and then `d`)
+You can now logout from the server.

--- a/host/README.md
+++ b/host/README.md
@@ -72,7 +72,7 @@ Install the service and launch it.
 
 ```
 $ sudo chown root:wheel launch.sh
-$ sudo cp com.mirego.ekiden /Library/LaunchDaemons
+$ sudo cp com.mirego.ekiden.plist /Library/LaunchDaemons
 $ sudo launchctl load -w /Library/LaunchDaemons/com.mirego.ekiden.plist
 ```
 

--- a/host/com.mirego.ekiden.plist
+++ b/host/com.mirego.ekiden.plist
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-	<dict>
-		<key>Label</key>
-		<string>com.mirego.ekiden</string>
-		<key>LaunchOnlyOnce</key>
-		<true/>
-		<key>ProgramArguments</key>
-		<array>
-			<string>sh</string>
-			<string>-c</string>
-			<string>/Users/admin/vm/launch.sh</string>
-		</array>
-		<key>WorkingDirectory</key>
-		<string>/Users/admin/vm</string>
-		<key>RunAtLoad</key>
-		<true/>
-	</dict>
+  <dict>
+    <key>Label</key>
+    <string>com.mirego.ekiden</string>
+    <key>LaunchOnlyOnce</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+      <string>sh</string>
+      <string>-c</string>
+      <string>/Users/admin/vm/launch.sh</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>/Users/admin/vm</string>
+    <key>RunAtLoad</key>
+    <true/>
+  </dict>
 </plist>

--- a/host/com.mirego.ekiden.plist
+++ b/host/com.mirego.ekiden.plist
@@ -17,9 +17,9 @@
     <key>WorkingDirectory</key>
     <string>/Users/admin/vm</string>
     <key>StandardErrorPath</key>
-    <string>/Users/admin/vm/stderr.log</string>
+    <string>/Users/admin/vm/stderr</string>
     <key>StandardOutPath</key>
-    <string>/Users/admin/vm/stdout.log</string>
+    <string>/Users/admin/vm/stdout</string>
     <key>RunAtLoad</key>
     <true/>
   </dict>

--- a/host/com.mirego.ekiden.plist
+++ b/host/com.mirego.ekiden.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>Label</key>
+		<string>com.mirego.ekiden</string>
+		<key>LaunchOnlyOnce</key>
+		<true/>
+		<key>ProgramArguments</key>
+		<array>
+			<string>sh</string>
+			<string>-c</string>
+			<string>/Users/admin/vm/launch.sh</string>
+		</array>
+		<key>WorkingDirectory</key>
+		<string>/Users/admin/vm</string>
+		<key>RunAtLoad</key>
+		<true/>
+	</dict>
+</plist>

--- a/host/com.mirego.ekiden.plist
+++ b/host/com.mirego.ekiden.plist
@@ -12,8 +12,14 @@
       <string>-c</string>
       <string>/Users/admin/vm/launch.sh</string>
     </array>
+    <key>UserName</key>
+    <string>admin</string>
     <key>WorkingDirectory</key>
     <string>/Users/admin/vm</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/admin/vm/stderr.log</string>
+    <key>StandardOutPath</key>
+    <string>/Users/admin/vm/stdout.log</string>
     <key>RunAtLoad</key>
     <true/>
   </dict>

--- a/host/launch.sh
+++ b/host/launch.sh
@@ -33,6 +33,9 @@ if [ -f .env ]; then
 	export $(xargs <.env)
 fi
 
+# Configure Homebrew
+eval "$(/opt/homebrew/bin/brew shellenv)"
+
 # Show a shutdown message when closing the script
 trap "log_output \"[HOST] 🚦 Stopping runner script\"; exit 1" SIGINT
 


### PR DESCRIPTION
## 📖 Description

Instead of relying on tmux to run the wrapping script (`launch.sh`), we now use the standard way to run services on macOS → `launchctl`.

## 📝 Notes

We need to use root to run the service (in `/Library/LaunchDaemons` and not `~/Library/LaunchDaemons`) as root.

## 🦀 Dispatch

- `#dispatch/devops`
