### PR TITLE
Suggest using Colima instead of Docker Desktop

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -11,7 +11,10 @@ This strategy uses 3 components:
 
 ## Prerequisites
 
-- Install [Docker](https://www.docker.com/)
+```
+$ brew install colima docker docker-compose
+$ colima start
+```
 
 ## Configuration
 


### PR DESCRIPTION
## 📖 Description

Instead of requiring Docker Desktop, let’s use [Colima](https://github.com/abiosoft/colima) instead.

## 📝 Notes

The next step will be to start Colima as a macOS service and start Grafana on boot.

## 🦀 Dispatch

- `#dispatch/devops`
