### PR TITLE
Use launchctl service to run monitoring services

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -19,7 +19,24 @@ $ colima start
 ## Configuration
 
 - Download the _monitoring_ folder from this repo to the machine.
+
+  ```
+  $ scp -r monitoring admin@<HOST_IP>:grafana
+  ```
+
 - Replace the HOST_URL and the MACHINE_NAME in promtail's configuration files.
 - Replace the HOST_URL in the `docker-compose.yaml`
-- Launch all components with `docker compose up -d`
+
+## Start the Containers
+
+On the remote machine, install the service and launch it.
+
+```
+$ sudo chown root:wheel launch.sh
+$ sudo cp com.mirego.ekiden-monitoring.plist /Library/LaunchDaemons
+$ sudo launchctl load -w /Library/LaunchDaemons/com.mirego.ekiden-monitoring.plist
+```
+
+## Post-Launch Configuration
+
 - _Optionally_ import the pre-built dashboard in the _grafana_ folder

--- a/monitoring/com.mirego.ekiden-monitoring.plist
+++ b/monitoring/com.mirego.ekiden-monitoring.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.mirego.ekiden-monitoring</string>
+    <key>LaunchOnlyOnce</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+      <string>sh</string>
+      <string>-c</string>
+      <string>/Users/admin/grafana/launch.sh</string>
+    </array>
+    <key>UserName</key>
+    <string>admin</string>
+    <key>WorkingDirectory</key>
+    <string>/Users/admin/grafana</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/admin/grafana/stderr</string>
+    <key>StandardOutPath</key>
+    <string>/Users/admin/grafana/stdout</string>
+    <key>RunAtLoad</key>
+    <true/>
+  </dict>
+</plist>

--- a/monitoring/docker-compose.yaml
+++ b/monitoring/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
       - ./grafana/:/var/lib/grafana
     environment:
       GF_SERVER_ROOT_URL: http://HOST_URL:3000
-  
+
   loki:
     image: grafana/loki:2.6.1
     ports:

--- a/monitoring/launch.sh
+++ b/monitoring/launch.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+colima start
+docker-compose up


### PR DESCRIPTION
## 📖 Description

Let’s use `launchctl` service to run monitoring settings, just like we do to run the VM & runner setup.

## 🦀 Dispatch

- `#dispatch/devops`