### PR TITLE
FIX:  Remove conflicting host reference if a previous IP get re-use for Guest VM

### DIFF
--- a/host/launch.sh
+++ b/host/launch.sh
@@ -69,6 +69,9 @@ function boot_vm {
 		sleep 1
 	done
 
+	# Clean old SSH host key reference for the VM to avoid conflicts
+	ssh-keygen -R "$IP_ADDRESS" >/dev/null
+
 	log_output "[HOST] 💤 Waiting for SSH to be available on VM" "$ENABLE_LOGGING"
 	until [ "$(SSHPASS=$VM_PASSWORD sshpass -e ssh -q -o ConnectTimeout=1 -o StrictHostKeyChecking=no "$VM_USERNAME@$IP_ADDRESS" pwd)" ]; do
 		sleep 1


### PR DESCRIPTION
## 📖 Description

Sometimes when a new Tart `guest` VM gets created on the host and the IP has already been use and remotely access, the `known-hosts` file get outdated data, so the new VM could no get ssh-ed on :O. So to fix this issue, jjust befor trying to ssh this VM, we weill remove any reference in that file under the same IP. If there is nothing currently existing, nothing will happen
<img width="755" alt="image" src="https://github.com/user-attachments/assets/6663febf-0068-4f47-a4e3-3ffd4bb32166" />

## 📓 References

N/A

## 🦀 Dispatch

- `#dispatch/devops`
